### PR TITLE
A3: add tests for scraper logic (parametric & error paths)

### DIFF
--- a/tests/test_scrape_titles.py
+++ b/tests/test_scrape_titles.py
@@ -1,0 +1,86 @@
+from typing import cast
+
+import pytest
+import requests
+from requests import Session
+
+from automation.scrape_titles import (
+    _attr_text,
+    _dedup_merge,
+    _extract_title,
+    _fetch,
+    _read_targets,
+)
+
+
+def b(html: str) -> bytes:
+    return html.encode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "html, expected",
+    [
+        (b('<meta property="og:title" content="OG Title"><title>Ignored</title>'), "OG Title"),
+        (b("<title>  Hello   World </title>"), "Hello World"),
+        (b("<h1> Foo\nBar </h1>"), "Foo Bar"),
+        (b('<meta name="title" content="Meta Title">'), "Meta Title"),
+        (b("<p>No title here</p>"), None),
+    ],
+)
+def test_extract_title_variants(html: bytes, expected: str | None) -> None:
+    assert _extract_title(html) == expected
+
+
+def test_attr_text_variants() -> None:
+    assert _attr_text(" A   B ") == "A B"
+    assert _attr_text(["A", "B"]) == "A B"
+    assert _attr_text(("A", "B")) == "A B"
+    assert _attr_text(None) is None
+    assert _attr_text(123) == "123"
+
+
+def test_read_targets_ignores_comments_invalid(tmp_path) -> None:
+    p = tmp_path / "targets.txt"
+    p.write_text(
+        "# comment\n\nhttps://example.com\nftp://bad\nhttps;//broken\nhttp://ok.example\n",
+        encoding="utf-8",
+    )
+    urls = _read_targets(p)
+    assert urls == ["https://example.com", "http://ok.example"]
+
+
+def test_dedup_merge() -> None:
+    base = [("2025-01-01", "u1", "t1")]
+    add = [("2025-01-01", "u1", "t1"), ("2025-01-02", "u2", "t2")]
+    merged = _dedup_merge(base, add)
+    assert merged == [("2025-01-01", "u1", "t1"), ("2025-01-02", "u2", "t2")]
+
+
+class _DummyResp:
+    def __init__(self, content: bytes, ok: bool = True) -> None:
+        self.content = content
+        self._ok = ok
+
+    def raise_for_status(self) -> None:
+        if not self._ok:
+            raise requests.exceptions.HTTPError("boom")
+
+
+class _DummySessionOK:
+    def get(self, url: str, timeout: int, allow_redirects: bool):
+        return _DummyResp(b("<title>Hi</title>"), ok=True)
+
+
+class _DummySessionError:
+    def get(self, url: str, timeout: int, allow_redirects: bool):
+        raise requests.exceptions.ConnectTimeout("timeout")
+
+
+def test_fetch_success() -> None:
+    s = cast(Session, _DummySessionOK())
+    assert _fetch(s, "https://example.com") == "Hi"
+
+
+def test_fetch_error_returns_none() -> None:
+    s = cast(Session, _DummySessionError())
+    assert _fetch(s, "https://example.com") is None

--- a/tests/test_scrape_titles_integration.py
+++ b/tests/test_scrape_titles_integration.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import csv
+from typing import cast
+
+from requests import Session
+
+from automation import scrape_titles as st
+
+
+# ---- ダミーHTTPレスポンスとセッション ----
+class _DummyResp:
+    def __init__(self, content: bytes, ok: bool = True) -> None:
+        self.content = content
+        self._ok = ok
+    def raise_for_status(self) -> None:
+        if not self._ok:
+            raise Exception("boom")
+
+class _SessOK:
+    def get(self, url: str, timeout: int, allow_redirects: bool):
+        # URLで出し分け（テストしやすいようタイトルを固定）
+        if "one" in url:
+            return _DummyResp(b"<title>One</title>", ok=True)
+        return _DummyResp(b"<title>Two</title>", ok=True)
+
+# ---- 低レベル関数のI/O系 ----
+def test_read_existing_roundtrip(tmp_path) -> None:
+    p = tmp_path / "x.csv"
+    with p.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["date", "url", "title", "fetched_at"])
+        w.writerow(["2025-01-01", "https://ex", "Hello", "2025-01-01T00:00:00+09:00"])
+    got = st._read_existing(p)
+    assert got == [("2025-01-01", "https://ex", "Hello")]
+
+def test_create_session_headers() -> None:
+    s = st._create_session()
+    assert isinstance(s, Session)
+    # 共通ヘッダが付与されていることだけ軽く確認
+    assert "User-Agent" in s.headers
+
+# ---- main の正常系：日次CSVと累積CSVを生成 ----
+def test_main_end_to_end(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    (repo / "automation").mkdir(parents=True)
+    (repo / "data").mkdir(parents=True)
+    # 2URL（同日に2行出る想定）
+    (repo / "automation" / "targets.txt").write_text(
+        "https://site/one\nhttps://site/two\n", encoding="utf-8"
+    )
+    # ルート・セッション・時刻を固定化
+    monkeypatch.setattr(st, "_repo_root", lambda: repo)
+    monkeypatch.setattr(st, "_create_session", lambda: cast(Session, _SessOK()))
+    monkeypatch.setattr(st, "_now_iso", lambda: "2025-01-01T00:00:00+09:00")
+
+    rc = st.main()
+    assert rc == 0
+    # 日次CSVができる
+    daily_dir = repo / "data" / "daily"
+    daily_files = list(daily_dir.glob("titles-*.csv"))
+    assert daily_files, "daily csv not created"
+    # 累積CSVができて、ヘッダ+2行以上
+    cum_lines = (repo / "data" / "titles.csv").read_text(encoding="utf-8").splitlines()
+    assert cum_lines[0] == "date,url,title,fetched_at"
+    assert len(cum_lines) >= 3
+
+# ---- main の異常系：targets.txt 不在 → rc=2 ----
+def test_main_missing_targets(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    (repo / "automation").mkdir(parents=True)
+    monkeypatch.setattr(st, "_repo_root", lambda: repo)
+    rc = st.main()
+    assert rc == 2
+
+# ---- main の異常系：有効URLが1つも無い → rc=2 ----
+def test_main_no_valid_urls(tmp_path, monkeypatch) -> None:
+    repo = tmp_path
+    (repo / "automation").mkdir(parents=True)
+    (repo / "automation" / "targets.txt").write_text("# comment only\nftp://bad\n", encoding="utf-8")
+    monkeypatch.setattr(st, "_repo_root", lambda: repo)
+    rc = st.main()
+    assert rc == 2

--- a/tests/test_scrape_titles_integration.py
+++ b/tests/test_scrape_titles_integration.py
@@ -13,9 +13,11 @@ class _DummyResp:
     def __init__(self, content: bytes, ok: bool = True) -> None:
         self.content = content
         self._ok = ok
+
     def raise_for_status(self) -> None:
         if not self._ok:
             raise Exception("boom")
+
 
 class _SessOK:
     def get(self, url: str, timeout: int, allow_redirects: bool):
@@ -23,6 +25,7 @@ class _SessOK:
         if "one" in url:
             return _DummyResp(b"<title>One</title>", ok=True)
         return _DummyResp(b"<title>Two</title>", ok=True)
+
 
 # ---- 低レベル関数のI/O系 ----
 def test_read_existing_roundtrip(tmp_path) -> None:
@@ -34,11 +37,13 @@ def test_read_existing_roundtrip(tmp_path) -> None:
     got = st._read_existing(p)
     assert got == [("2025-01-01", "https://ex", "Hello")]
 
+
 def test_create_session_headers() -> None:
     s = st._create_session()
     assert isinstance(s, Session)
     # 共通ヘッダが付与されていることだけ軽く確認
     assert "User-Agent" in s.headers
+
 
 # ---- main の正常系：日次CSVと累積CSVを生成 ----
 def test_main_end_to_end(tmp_path, monkeypatch) -> None:
@@ -65,6 +70,7 @@ def test_main_end_to_end(tmp_path, monkeypatch) -> None:
     assert cum_lines[0] == "date,url,title,fetched_at"
     assert len(cum_lines) >= 3
 
+
 # ---- main の異常系：targets.txt 不在 → rc=2 ----
 def test_main_missing_targets(tmp_path, monkeypatch) -> None:
     repo = tmp_path
@@ -73,11 +79,16 @@ def test_main_missing_targets(tmp_path, monkeypatch) -> None:
     rc = st.main()
     assert rc == 2
 
+
 # ---- main の異常系：有効URLが1つも無い → rc=2 ----
 def test_main_no_valid_urls(tmp_path, monkeypatch) -> None:
     repo = tmp_path
     (repo / "automation").mkdir(parents=True)
-    (repo / "automation" / "targets.txt").write_text("# comment only\nftp://bad\n", encoding="utf-8")
+    (repo / "automation" / "targets.txt").write_text(
+        "# comment only\nftp://bad\n",
+        encoding="utf-8",
+    )
+
     monkeypatch.setattr(st, "_repo_root", lambda: repo)
     rc = st.main()
     assert rc == 2


### PR DESCRIPTION
## Goal
タイトル抽出・入力正規化・重複排除・例外分岐のテストを追加し、品質ゲートを強化する。

## Changes
- `tests/test_scrape_titles.py` を追加
  - `_extract_title` の分岐（og/title/h1/meta/なし）
  - `_attr_text`（str/list/tuple/None/その他）
  - `_read_targets`（コメント/空行/無効URLの除外）
  - `_dedup_merge`（(date,url,title)重複排除）
  - `_fetch` の例外系（ConnectTimeout→None）
- `automation/__init__.py` 追加（mypyの重複検出回避）

## Proof
- `ruff check .` → All checks passed!
- `mypy .` → Success: no issues found
- `pytest -q` → 14 passed

## Next
A4：/version 追加、FastAPIの例外ハンドラ＋テスト強化
