### PR TITLE
A4: add /version and exception handlers with tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 from fastapi import FastAPI
 from fastapi import Path as FPath
-from pydantic import BaseModel
+from pydantic import BaseModel  # noqa: E402
 
 # ① .env を読む Settings をインポート
 from settings import settings
@@ -58,3 +58,69 @@ def health():
         "db": settings.db_url,  # .env の DB_URL がそのまま入る
         "api": settings.api_key,  # 同じく API_KEY
     }
+
+
+# --- A4: version endpoint & exception handlers ---
+import os  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+from datetime import UTC, datetime  # noqa: E402
+
+from fastapi import Request  # noqa: E402
+from fastapi.exception_handlers import request_validation_exception_handler  # noqa: E402
+from fastapi.exceptions import RequestValidationError  # noqa: E402
+from fastapi.responses import JSONResponse  # noqa: E402
+from pydantic import BaseModel  # noqa: E402
+
+# アプリ起動時刻（ISO8601）
+_STARTED_AT = datetime.now(UTC).astimezone().isoformat(timespec="seconds")
+
+
+def _git_sha_short() -> str:
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
+        )  # noqa: E501  # noqa: E501
+        return sha.decode("utf-8").strip()
+    except Exception:
+        return os.getenv("GIT_SHA", "unknown")
+
+
+def _app_version() -> str:
+    # .env などで APP_VERSION があればそれを使う。無ければ 0.1.0 とする。
+    return os.getenv("APP_VERSION", "0.1.0")
+
+
+class VersionInfo(BaseModel):
+    version: str
+    git_sha: str
+    started_at: str
+    python: str
+
+
+@app.get("/version", response_model=VersionInfo)
+def version() -> VersionInfo:
+    return VersionInfo(
+        version=_app_version(),
+        git_sha=_git_sha_short(),
+        started_at=_STARTED_AT,
+        python=sys.version.split()[0],
+    )
+
+
+# 422: 既定ハンドラを呼び出して形を変えない（ロギング用途に差し替え可）
+@app.exception_handler(RequestValidationError)
+async def _handle_422(request: Request, exc: RequestValidationError):
+    return await request_validation_exception_handler(request, exc)
+
+
+# 500: 共通 JSON を返す
+@app.exception_handler(Exception)
+async def _handle_500(request: Request, exc: Exception):
+    return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+
+
+# テスト用のエンドポイント（本番では参照されない）
+@app.get("/__error")
+def _boom() -> None:  # pragma: no cover
+    raise RuntimeError("boom")

--- a/tests/test_version_and_handlers.py
+++ b/tests/test_version_and_handlers.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+# ここがポイント：サーバ例外をレスポンスにする
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_version_endpoint() -> None:
+    r = client.get("/version")
+    assert r.status_code == 200
+    data = r.json()
+    for k in ("version", "git_sha", "started_at", "python"):
+        assert k in data
+    assert "T" in data["started_at"] and ("+" in data["started_at"] or "Z" in data["started_at"])
+
+
+def test_internal_server_error_handler() -> None:
+    r = client.get("/__error")
+    assert r.status_code == 500
+    assert r.json() == {"detail": "Internal Server Error"}


### PR DESCRIPTION
## Goal
/version を追加し、例外ハンドラ（422/500）を整備する。

## Changes
- `GET /version`（version/git_sha/started_at/python）
- 422: 既定ハンドラに委譲（将来ロギング用）
- 500: `{"detail":"Internal Server Error"}` を返す
- テスト: version 正常系、500 のハンドラ

## Proof
- ruff: All checks passed
- mypy: Success
- pytest+cov: 6 passed, Total coverage 94.79% (>=80%)

## Notes
- CI環境で `git` が使えない場合も `GIT_SHA` 環境変数でフォールバック
