### PR TITLE
chore: add kamikouryaku URL & captured CSV (A1 sample)

### DIFF
--- a/data/daily/titles-20250828.csv
+++ b/data/daily/titles-20250828.csv
@@ -1,0 +1,4 @@
+date,url,title,fetched_at
+2025-08-28,https://www.example.com/,Example Domain,2025-08-28T07:49:34+09:00
+2025-08-28,https://www.python.org/,Welcome to Python.org,2025-08-28T07:49:34+09:00
+2025-08-28,https://kamikouryaku.net/nightreign_eldenring/?%E3%83%AC%E3%83%87%E3%82%A3,レディ,2025-08-28T07:49:34+09:00

--- a/data/titles.csv
+++ b/data/titles.csv
@@ -1,5 +1,8 @@
 date,url,title,fetched_at
-2025-08-23,https://www.example.com/,Example Domain,2025-08-24T09:56:10+09:00
-2025-08-23,https://www.python.org/,Welcome to Python.org,2025-08-24T09:56:10+09:00
-2025-08-24,https://www.example.com/,Example Domain,2025-08-24T09:56:10+09:00
-2025-08-24,https://www.python.org/,Welcome to Python.org,2025-08-24T09:56:10+09:00
+2025-08-23,https://www.example.com/,Example Domain,2025-08-28T07:49:34+09:00
+2025-08-23,https://www.python.org/,Welcome to Python.org,2025-08-28T07:49:34+09:00
+2025-08-24,https://www.example.com/,Example Domain,2025-08-28T07:49:34+09:00
+2025-08-24,https://www.python.org/,Welcome to Python.org,2025-08-28T07:49:34+09:00
+2025-08-28,https://www.example.com/,Example Domain,2025-08-28T07:49:34+09:00
+2025-08-28,https://www.python.org/,Welcome to Python.org,2025-08-28T07:49:34+09:00
+2025-08-28,https://kamikouryaku.net/nightreign_eldenring/?%E3%83%AC%E3%83%87%E3%82%A3,レディ,2025-08-28T07:49:34+09:00


### PR DESCRIPTION
## What
- Add https://kamikouryaku.net/... to automation/targets.txt
- Capture daily/cumulative CSV including the new page title

## Why
A1の実行結果をGitHub上で可視化（差分確認用）

## Proof
- targets.txt: +1 line (kamikouryaku)
- data/daily/titles-YYYYMMDD.csv: new file with 3 rows
- data/titles.csv: cumulative has the new row (kamikouryaku)
