### PR TITLE
A11: schedule daily scrape & auto-PR

### DIFF
--- a/.github/workflows/a11-scheduled-scrape.yml
+++ b/.github/workflows/a11-scheduled-scrape.yml
@@ -1,0 +1,67 @@
+name: "A11: scheduled scrape & PR"
+
+on:
+  schedule:
+    # UTC 00:00 = JST 09:00
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}  # 手動実行
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: a11-scrape
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Create .env for script/tests
+        run: |
+          printf "DB_URL=postgresql://example\nAPI_KEY=secret\n" > .env
+
+      - name: Run scraper
+        run: python automation/scrape_titles.py
+
+      - name: Upload CSV artifact (for debugging)
+        uses: actions/upload-artifact@v4
+        with:
+          name: scraped-csv
+          path: |
+            data/titles.csv
+            data/daily/*.csv
+
+      - name: Create PR with changes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(data): daily scrape"
+          branch: "chore/daily-scrape-${{ github.run_id }}"
+          title: "A11: daily scrape (data/titles.csv)"
+          body: |
+            ## Summary
+            Run automation/scrape_titles.py daily (09:00 JST), commit results, and open a PR.
+
+            ## Changes
+            - Update data/daily/titles-YYYYMMDD.csv
+            - Merge into data/titles.csv (dedup)
+
+            ## Why
+            Keep the dataset fresh automatically.
+
+            ## How to verify
+            - This PR includes updated CSVs with today's date.
+            - CI checks are green.
+          labels: data, automation
+          delete-branch: true


### PR DESCRIPTION
## Summary
Run automation/scrape_titles.py daily (09:00 JST). The workflow commits CSV updates and opens a PR automatically.

## Changes
- Add .github/workflows/a11-scheduled-scrape.yml
- Enable workflow_dispatch for manual triggers

## Why
Keep titles.csv fresh automatically with a reproducible job.

## How to verify
- After merge: Actions → "A11: scheduled scrape & PR" → Run workflow
- A bot PR appears with updated CSVs (data/daily/… & data/titles.csv)
- CI is green
