### PR TITLE
A11: reuse single PR branch (chore/daily-scrape) to avoid duplicates

### DIFF
--- a/.github/workflows/a11-scheduled-scrape.yml
+++ b/.github/workflows/a11-scheduled-scrape.yml
@@ -50,7 +50,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "chore(data): daily scrape"
-          branch: "chore/daily-scrape-${{ github.run_id }}"
+          branch: chore/daily-scrape
           title: "A11: daily scrape (data/titles.csv)"
           body: |
             ## Summary


### PR DESCRIPTION
## Summary
A11 の自動 PR 作成ステップで使うブランチ名を固定化しました。
- 変更前: branch: "chore/daily-scrape-${{ github.run_id }}"（実行毎に新規ブランチ）
- 変更後: branch: chore/daily-scrape（同じブランチを使い回し）

## Changes
- .github/workflows/a11-scheduled-scrape.yml
  - with.branch を `chore/daily-scrape` に固定

## Why
- 実行のたびに PR が複数できるのを防ぎ、**常に PR が1つ**の状態を保つため
- 既存 PR が開いていればその PR にコミットが積まれる（重複しない）

## How to verify
1. Actions → 「A11: scheduled scrape & PR」→ `Run workflow` を実行
2. 「A11: daily scrape (data/titles.csv)」の PR が **新規作成/更新**されること
3. CI がすべて緑になること
