### PR TITLE
A17: Playwrightでログイン必要サイトの取得（Twitch）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ PY
 
 # generated daily CSVs
 /data/daily/
+tmp/

--- a/automation/scrape_twitch.py
+++ b/automation/scrape_twitch.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from playwright.async_api import async_playwright
+
+load_dotenv()
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+LOGIN_URL = os.getenv("PLAYWRIGHT_LOGIN_URL", "https://www.twitch.tv/login")
+USERNAME = os.getenv("PLAYWRIGHT_USERNAME")
+PASSWORD = os.getenv("PLAYWRIGHT_PASSWORD")
+TARGET_URL = os.getenv("PLAYWRIGHT_TARGET_URL", "https://www.twitch.tv/")
+
+
+async def run(dry_run: bool = False) -> None:
+    if not USERNAME or not PASSWORD:
+        raise RuntimeError("PLAYWRIGHT_USERNAME / PLAYWRIGHT_PASSWORD を .env に入れてください")
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+        try:
+            # 1) ログインページへ
+            await page.goto(LOGIN_URL, wait_until="networkidle", timeout=25_000)
+
+            # 2) ユーザー名を入れる（あるもの全部に投げる）
+            await page.fill("input#login-username, input[name='login'], input#username", USERNAME)
+
+            # 3) パスワード欄を待ってから入れる
+            await page.wait_for_selector(
+                "input#password, input[name='password'], input[type='password']",
+                timeout=15_000,
+            )
+            await page.fill(
+                "input#password, input[name='password'], input[type='password']",
+                PASSWORD,
+            )
+
+            # 4) ログインボタン
+            await page.click(
+                "button[data-a-target='passport-login-button'], "
+                "button:has-text('Log In'), button:has-text('ログイン')"
+            )
+
+            # 5) ログイン後ページへ
+            await page.goto(TARGET_URL, wait_until="networkidle", timeout=25_000)
+
+            if dry_run:
+                print("[DRY RUN] twitch login/page ok")
+            else:
+                html = await page.content()
+                (OUTPUT_DIR / "twitch.html").write_text(html, encoding="utf-8")
+                print("saved to tmp/twitch.html")
+
+            await browser.close()
+        except Exception as e:  # noqa: BLE001
+            screenshot_path = OUTPUT_DIR / "twitch-error.png"
+            try:
+                await page.screenshot(path=str(screenshot_path), full_page=True)
+            except Exception:
+                pass
+            await browser.close()
+            raise RuntimeError(f"Twitch scraping failed: {e}. screenshot={screenshot_path}") from e
+
+
+def main() -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    asyncio.run(run(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,5 @@ requests
 beautifulsoup4
 lxml
 pyarrow
+playwright
+python-dotenv

--- a/settings.py
+++ b/settings.py
@@ -1,15 +1,23 @@
-# settings.py
-
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    # 既存
     db_url: str | None = None
     api_key: str | None = None
 
+    # A17: Playwright用の設定を追加
+    playwright_login_url: str | None = None
+    playwright_username: str | None = None
+    playwright_password: str | None = None
+    playwright_target_url: str | None = None
+
+    # 共通設定
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        extra="ignore",  # ← .envに知らないキーがあっても落ちないようにする
+        case_sensitive=False,  # ← PLAYWRIGHT_... の大文字小文字をゆるく
     )
 
 

--- a/tests/test_scrape_twitch_import.py
+++ b/tests/test_scrape_twitch_import.py
@@ -1,0 +1,2 @@
+def test_can_import_twitch_scraper():
+    import automation.scrape_twitch  # noqa: F401


### PR DESCRIPTION
- automation/scrape_twitch.py を追加
- .env から Twitch のログイン情報を読むようにした
- 失敗時は tmp/twitch-error.png にスクショ保存
- settings.py に Playwright 用の設定項目を追加
- import が壊れてないか見る簡単なpytestを追加
