### PR TITLE
A19: 観測ログと /health 拡張を追加

### DIFF
--- a/observability.py
+++ b/observability.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any
+
+LOGGER_NAME = "mlops_app"
+
+logger = logging.getLogger(LOGGER_NAME)
+logger.setLevel(logging.INFO)
+
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter("%(message)s"))
+logger.handlers.clear()
+logger.addHandler(handler)
+
+
+def log_event(event: str, **fields: Any) -> None:
+    """
+    構造化ログを1行JSONで出すためのヘルパー。
+
+    例:
+        log_event("scrape_finished", count=123, duration_ms=456)
+    """
+    record: dict[str, Any] = {
+        "event": event,
+        "ts": time.time(),
+        **fields,
+    }
+    logger.info(json.dumps(record, ensure_ascii=False))
+
+
+@contextmanager
+def time_block(event: str, **fields: Any):
+    """
+    処理時間を計測しつつ、成功/失敗も含めてログに出すコンテキストマネージャ。
+
+    例:
+        with time_block("scrape_titles", target="a16z"):
+            run_scraper()
+    """
+    start = time.time()
+    try:
+        yield
+        duration = time.time() - start
+        log_event(
+            event,
+            duration_ms=int(duration * 1000),
+            success=True,
+            **fields,
+        )
+    except Exception as exc:  # noqa: BLE001
+        duration = time.time() - start
+        log_event(
+            event,
+            duration_ms=int(duration * 1000),
+            success=False,
+            error=str(exc),
+            **fields,
+        )
+        raise


### PR DESCRIPTION
◾️What
観測用モジュール observability.py を追加
automation/scrape_titles.py に JSON ログ（件数・処理時間など）を追加
/health に uptime_sec と簡易チェックを追加し、構造化ログも出力

◾️How
log_event() で 1行1JSON の構造化ログを出力
time_block() でスクレイプ全体の処理時間＋成功/失敗を計測
health_checks() で Settings 読み込み前提＋ data/ ディレクトリの存在を確認

◾️Verify
pytest -q が成功する
python -m automation.scrape_titles 実行時に scrape_titles_* のJSONログが出る
uvicorn main:app --reload 起動後、/health が status=ok を返し、health_check ログが出る