### PR TITLE
B8: /health に Iris モデル状態を追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from automation.storage import fts_search_articles, search_articles
-from ml_sample.model import ensure_model
+from ml_sample.model import ensure_model, get_model_status
 from ml_sample.model import predict as iris_predict
 from settings import settings
 
@@ -91,6 +91,7 @@ def health():
         "status": "ok",
         "db": settings.db_url,  # .env の DB_URL がそのまま入る
         "api": settings.api_key,  # 同じく API_KEY
+        "iris_model": get_model_status(),  # Iris モデルの状態を追加
     }
 
 

--- a/ml_sample/model.py
+++ b/ml_sample/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import joblib
 import numpy as np
@@ -64,6 +65,15 @@ def predict(
     else:
         label = "unknown"
     return cls, label
+
+
+def get_model_status(model_path: Path | None = None) -> Literal["ready", "missing"]:
+    """モデルファイルが存在すれば 'ready'、無ければ 'missing' を返す。"""
+    if model_path is None:
+        model_path = MODEL_PATH
+    if model_path.exists():
+        return "ready"
+    return "missing"
 
 
 def main() -> int:


### PR DESCRIPTION
## 概要
- `/health` で Iris モデルの状態を確認できるようにする変更です。

## 変更内容
- `ml_sample/model.py`
  - Iris データセットを学習して `models/iris-model.joblib` に保存する `train_and_save_model()` を追加
  - 保存済みモデルを読み込む `load_model()` を追加
  - モデルファイルの有無を返す `get_model_status()` を追加
- `main.py`
  - `/health` のレスポンスに `iris_model` フィールドを追加
    - モデルがあれば `"ready"`, 無ければ `"missing"` を返す

## 動作確認
- モデル学習
  - `source .venv/bin/activate`
  - `mlops-try train-iris`
- API 起動
  - `uvicorn main:app --reload`
- ヘルスチェック
  - `curl http://127.0.0.1:8000/health`
  - `iris_model` が `"ready"` になっていることを確認
    - 例: `{"status":"ok", ..., "iris_model":"ready"}`

## メモ
- モデルファイルを削除した場合は `iris_model: "missing"` になる想定です。