### PR TITLE
B9.5: Add CLI entrypoint for Iris model evaluation

### DIFF
--- a/ml_sample/eval_cli.py
+++ b/ml_sample/eval_cli.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .eval import evaluate_iris_model
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """コマンドライン引数をパースする。"""
+    parser = argparse.ArgumentParser(
+        description="Evaluate Iris model and export metrics as JSON files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("metrics"),
+        help="Directory to store metrics JSON files (default: ./metrics)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Iris モデル評価 CLI のエントリポイント。"""
+    args = parse_args(argv)
+
+    result = evaluate_iris_model(output_dir=args.output_dir)
+
+    metrics_path = result.metrics_path
+    try:
+        metrics_path = metrics_path.relative_to(Path.cwd())
+    except ValueError:
+        # カレントディレクトリ外の場合はそのまま表示
+        pass
+
+    print(f"Metrics saved to: {metrics_path}")
+    print(f"Accuracy: {result.accuracy:.4f}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_iris_eval_cli.py
+++ b/tests/test_iris_eval_cli.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_eval_cli_creates_metrics_and_prints_accuracy(tmp_path: Path) -> None:
+    """CLI から評価を実行すると、メトリクスと Accuracy 表示が行われることを確認する。"""
+    result = subprocess.run(
+        [sys.executable, "-m", "ml_sample.eval_cli", "--output-dir", str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # 標準出力にキーワードが含まれていること
+    stdout = result.stdout
+    assert "Metrics saved to:" in stdout
+    assert "Accuracy:" in stdout
+
+    # 出力ディレクトリにメトリクスファイルが作成されていること
+    files = list(tmp_path.iterdir())
+    assert files, "output_dir にファイルが作成されていません"
+
+    latest_path = tmp_path / "iris-latest.json"
+    assert latest_path.exists(), "iris-latest.json が作成されていません"


### PR DESCRIPTION
◾️What
- Iris モデル評価用の CLI エントリポイント `ml_sample/eval_cli.py` を追加
- `python -m ml_sample.eval_cli` で評価を実行し、メトリクスJSON出力＋Accuracy表示を行う
- `tests/test_iris_eval_cli.py` で CLI からの実行を pytest で検証

◾️How
- argparse で `--output-dir` オプションを受け取り、メトリクス保存先を指定可能にした
- 内部では既存の `evaluate_iris_model()` を呼び出し、JSONファイル生成ロジックを再利用
- 実行結果として、メトリクスファイルパスと Accuracy を標準出力に表示

◾️Verify
- `python -m ml_sample.eval_cli` を実行し、`Metrics saved to: ...` と `Accuracy: ...` が表示されること
- `python -m ml_sample.eval_cli --output-dir /tmp/iris-metrics` など別ディレクトリ指定でもメトリクスが生成されること
- `ruff check . --fix && ruff format . && mypy . && pytest -q` がローカルで成功すること
