### PR TITLE
B13: Iris評価メトリクス履歴をASCIIグラフで可視化するCLIを追加

### DIFF
--- a/tests/test_iris_metrics_summary_chart.py
+++ b/tests/test_iris_metrics_summary_chart.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_metrics(path: Path, created_at: str, accuracy: float) -> None:
+    data = {
+        "created_at": created_at,
+        "accuracy": accuracy,
+        "n_samples": 150,
+        "classification_report": {},
+        "confusion_matrix": [],
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_metrics_summary_ascii_chart_output(tmp_path: Path) -> None:
+    metrics_dir = tmp_path / "metrics"
+    metrics_dir.mkdir()
+
+    older = metrics_dir / "iris-20251201-000000.json"
+    newer = metrics_dir / "iris-20251202-000000.json"
+
+    _write_metrics(
+        older,
+        created_at="2025-12-01T00:00:00+00:00",
+        accuracy=0.90,
+    )
+    _write_metrics(
+        newer,
+        created_at="2025-12-02T00:00:00+00:00",
+        accuracy=0.95,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ml_sample.metrics_summary",
+            "--metrics-dir",
+            str(metrics_dir),
+            "--ascii-chart",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    lines = [line for line in result.stdout.strip().splitlines() if line]
+
+    # 先頭のヘッダ
+    assert lines[0] == "Iris accuracy chart"
+    assert lines[1].startswith("----------------")
+
+    # 2 行目以降に日付と accuracy が含まれていること
+    joined = "\n".join(lines)
+    assert "2025-12-01" in joined
+    assert "2025-12-02" in joined
+    assert "(0.9000)" in joined
+    assert "(0.9500)" in joined


### PR DESCRIPTION
◾️What
- Iris 評価メトリクス履歴を ASCII グラフで可視化するオプションを追加
- `python -m ml_sample.metrics_summary --ascii-chart` で、日付ごとの accuracy を棒グラフ風に表示できるようにした

◾️How
- `ml_sample.metrics_summary` に `--ascii-chart` オプションを追加し、`--tsv` と排他指定できるようにした
- accuracy (0.0〜1.0) を最大 40 文字の `#` にスケーリングして、`YYYY-MM-DD | ###... (0.xxxx)` 形式で出力
- `tests/test_iris_metrics_summary_chart.py` を追加し、サンプルの `iris-*.json` を使って日付と accuracy が期待どおり出力されることを pytest で検証

◾️Verify
- `python -m ml_sample.metrics_summary` が従来どおりテーブル形式で動作すること
- `python -m ml_sample.metrics_summary --tsv` で TSV 出力が行われること
- `python -m ml_sample.metrics_summary --ascii-chart` で、ヘッダ行に続いて日付と `(0.9000)` のような accuracy 表示を含む ASCII グラフが出力されること
- `ruff check . --fix && ruff format . && mypy . && pytest -q` がローカルで成功していること
