### PR TITLE
B14: Docker compose で FastAPI + Iris API を起動できるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,25 @@ Iris ML デモについて（概要）
 
 ライセンス
 本プロジェクトは MIT License のもとで公開予定です。
+## Docker での起動
+
+このリポジトリは、Docker コンテナとしても起動できます。
+FastAPI アプリと Iris ML API をまとめて立ち上げられるので、検証やデモに使いやすい構成です。
+
+### 前提
+
+- Docker 環境がインストールされていること（Docker Desktop など）
+- プロジェクト直下に `.env` があること（`cp .env.example .env` で作成可能）
+
+### 起動手順
+
+```bash
+docker compose up --build
+
+起動後、次の URL にアクセスできます。
+ヘルスチェック: http://localhost:8000/health
+API ドキュメント (Swagger UI): http://localhost:8000/docs
+Iris ML API: POST http://localhost:8000/ml/iris/predict
+
+停止
+docker compose down


### PR DESCRIPTION
◾️What
* FastAPI + Iris ML API を Docker コンテナとして起動し、docker compose up --build だけで動かせることを確認しました。
* README に Docker ベースの起動手順（前提 / 起動 / 停止）を追記しました。

◾️How
* 既存の Dockerfile / docker-compose.yml を利用してアプリケーションコンテナをビルド・起動。
* ホスト側から /health と /ml/iris/predict に対して curl を実行し、コンテナ経由で正常にレスポンスが返ることを確認。
* README に「Docker での起動」セクションを追加し、ポートフォリオとしても説明しやすい形に整理しました。

◾️Verify
* ローカル環境で以下を実行し、正常動作を確認しました。
    * docker compose up --build
    * curl http://localhost:8000/health
    * curl -X POST http://localhost:8000/ml/iris/predict ...
* ruff check . --fix && ruff format . && mypy . && pytest -q がすべて成功しています。
